### PR TITLE
Additional methods for Folding

### DIFF
--- a/src/ScintillaNET/Scintilla.cs
+++ b/src/ScintillaNET/Scintilla.cs
@@ -834,6 +834,16 @@ namespace ScintillaNET
         }
 
         /// <summary>
+        /// Expand or contract a fold header and its children.
+        /// </summary>
+        /// <param name="line">Line number on which action should be performed</param>
+        /// <param name="action">Fold Action</param>
+        public void FoldChildren(int line, FoldAction action)
+        {
+            DirectMessage(NativeMethods.SCI_FOLDCHILDREN, new IntPtr((int)line), new IntPtr((int)action));
+        }
+
+        /// <summary>
         /// Returns the character as the specified document position.
         /// </summary>
         /// <param name="position">The zero-based document position of the character to get.</param>

--- a/src/ScintillaNET/Scintilla.cs
+++ b/src/ScintillaNET/Scintilla.cs
@@ -897,6 +897,17 @@ namespace ScintillaNET
             var pos = DirectMessage(NativeMethods.SCI_GETENDSTYLED).ToInt32();
             return Lines.ByteToCharPosition(pos);
         }
+        
+        /// <summary>
+        /// Gets the line number of the first line before startLine that is marked as a fold point, and has a fold level less than the startLine.
+        /// If no line is found, or or if the header flags and fold levels are inconsistent, the return value is -1.
+        /// </summary>
+        /// <param name="startLine"></param>
+        /// <returns></returns>
+        public int GetFoldParent(int startLine)
+        {
+            return DirectMessage(NativeMethods.SCI_GETFOLDPARENT, new IntPtr(startLine)).ToInt32();
+        }
 
         private static string GetModulePath()
         {


### PR DESCRIPTION
Hi,

I added the `FoldChildren(int line, FoldAction action)` and `GetFoldParent(int startLine)` methods. The `FoldAll(FoldAction.Contract)` method only contracts the top-level folder (from what I can see this is handled by the native Scintilla dll?). By using the `FoldChildren()` on the first fold line, it is possible to contract all folders.

Btw, thanks for the excellent work with the wrapper.

Regards,
Ivan Slabbert