### PR TITLE
Update types in the SCNotification struct

### DIFF
--- a/src/ScintillaNET/NativeMethods.cs
+++ b/src/ScintillaNET/NativeMethods.cs
@@ -1866,17 +1866,17 @@ namespace ScintillaNET
         public struct SCNotification
         {
             public Sci_NotifyHeader nmhdr;
-            public int position;
+            public IntPtr position;
             public int ch;
             public int modifiers;
             public int modificationType;
             public IntPtr text;
-            public int length;
-            public int linesAdded;
+            public IntPtr length;
+            public IntPtr linesAdded;
             public int message;
             public IntPtr wParam;
             public IntPtr lParam;
-            public int line;
+            public IntPtr line;
             public int foldLevelNow;
             public int foldLevelPrev;
             public int margin;
@@ -1884,7 +1884,7 @@ namespace ScintillaNET
             public int x;
             public int y;
             public int token;
-            public int annotationLinesAdded;
+            public IntPtr annotationLinesAdded;
             public int updated;
             public int listCompletionMethod;
         }

--- a/src/ScintillaNET/Scintilla.cs
+++ b/src/ScintillaNET/Scintilla.cs
@@ -2036,14 +2036,14 @@ namespace ScintillaNET
         private void ScnDoubleClick(ref NativeMethods.SCNotification scn)
         {
             var keys = Keys.Modifiers & (Keys)(scn.modifiers << 16);
-            var eventArgs = new DoubleClickEventArgs(this, keys, scn.position, scn.line);
+            var eventArgs = new DoubleClickEventArgs(this, keys, scn.position.ToInt32(), scn.line.ToInt32());
             OnDoubleClick(eventArgs);
         }
 
         private void ScnHotspotClick(ref NativeMethods.SCNotification scn)
         {
             var keys = Keys.Modifiers & (Keys)(scn.modifiers << 16);
-            var eventArgs = new HotspotClickEventArgs(this, keys, scn.position);
+            var eventArgs = new HotspotClickEventArgs(this, keys, scn.position.ToInt32());
             switch (scn.nmhdr.code)
             {
                 case NativeMethods.SCN_HOTSPOTCLICK:
@@ -2066,11 +2066,11 @@ namespace ScintillaNET
             {
                 case NativeMethods.SCN_INDICATORCLICK:
                     var keys = Keys.Modifiers & (Keys)(scn.modifiers << 16);
-                    OnIndicatorClick(new IndicatorClickEventArgs(this, keys, scn.position));
+                    OnIndicatorClick(new IndicatorClickEventArgs(this, keys, scn.position.ToInt32()));
                     break;
 
                 case NativeMethods.SCN_INDICATORRELEASE:
-                    OnIndicatorRelease(new IndicatorReleaseEventArgs(this, scn.position));
+                    OnIndicatorRelease(new IndicatorReleaseEventArgs(this, scn.position.ToInt32()));
                     break;
             }
         }
@@ -2078,7 +2078,7 @@ namespace ScintillaNET
         private void ScnMarginClick(ref NativeMethods.SCNotification scn)
         {
             var keys = Keys.Modifiers & (Keys)(scn.modifiers << 16);
-            var eventArgs = new MarginClickEventArgs(this, keys, scn.position, scn.margin);
+            var eventArgs = new MarginClickEventArgs(this, keys, scn.position.ToInt32(), scn.margin);
 
             if (scn.nmhdr.code == NativeMethods.SCN_MARGINCLICK)
                 OnMarginClick(eventArgs);
@@ -2094,7 +2094,7 @@ namespace ScintillaNET
 
             if ((scn.modificationType & NativeMethods.SC_MOD_INSERTCHECK) > 0)
             {
-                var eventArgs = new InsertCheckEventArgs(this, scn.position, scn.length, scn.text);
+                var eventArgs = new InsertCheckEventArgs(this, scn.position.ToInt32(), scn.length.ToInt32(), scn.text);
                 OnInsertCheck(eventArgs);
 
                 cachedPosition = eventArgs.CachedPosition;
@@ -2106,7 +2106,7 @@ namespace ScintillaNET
             if ((scn.modificationType & (NativeMethods.SC_MOD_BEFOREDELETE | NativeMethods.SC_MOD_BEFOREINSERT)) > 0)
             {
                 var source = (ModificationSource)(scn.modificationType & sourceMask);
-                var eventArgs = new BeforeModificationEventArgs(this, source, scn.position, scn.length, scn.text);
+                var eventArgs = new BeforeModificationEventArgs(this, source, scn.position.ToInt32(), scn.length.ToInt32(), scn.text);
 
                 eventArgs.CachedPosition = cachedPosition;
                 eventArgs.CachedText = cachedText;
@@ -2127,7 +2127,7 @@ namespace ScintillaNET
             if ((scn.modificationType & (NativeMethods.SC_MOD_DELETETEXT | NativeMethods.SC_MOD_INSERTTEXT)) > 0)
             {
                 var source = (ModificationSource)(scn.modificationType & sourceMask);
-                var eventArgs = new ModificationEventArgs(this, source, scn.position, scn.length, scn.text, scn.linesAdded);
+                var eventArgs = new ModificationEventArgs(this, source, scn.position.ToInt32(), scn.length.ToInt32(), scn.text, scn.linesAdded.ToInt32());
 
                 eventArgs.CachedPosition = cachedPosition;
                 eventArgs.CachedText = cachedText;
@@ -2152,7 +2152,7 @@ namespace ScintillaNET
 
             if ((scn.modificationType & NativeMethods.SC_MOD_CHANGEANNOTATION) > 0)
             {
-                var eventArgs = new ChangeAnnotationEventArgs(scn.line);
+                var eventArgs = new ChangeAnnotationEventArgs(scn.line.ToInt32());
                 OnChangeAnnotation(eventArgs);
             }
         }
@@ -2724,7 +2724,7 @@ namespace ScintillaNET
                         break;
 
                     case NativeMethods.SCN_STYLENEEDED:
-                        OnStyleNeeded(new StyleNeededEventArgs(this, scn.position));
+                        OnStyleNeeded(new StyleNeededEventArgs(this, scn.position.ToInt32()));
                         break;
 
                     case NativeMethods.SCN_SAVEPOINTLEFT:
@@ -2749,11 +2749,11 @@ namespace ScintillaNET
                         break;
 
                     case NativeMethods.SCN_AUTOCSELECTION:
-                        OnAutoCSelection(new AutoCSelectionEventArgs(this, scn.position, scn.text, scn.ch, (ListCompletionMethod)scn.listCompletionMethod));
+                        OnAutoCSelection(new AutoCSelectionEventArgs(this, scn.position.ToInt32(), scn.text, scn.ch, (ListCompletionMethod)scn.listCompletionMethod));
                         break;
 
                     case NativeMethods.SCN_AUTOCCOMPLETED:
-                        OnAutoCCompleted(new AutoCSelectionEventArgs(this, scn.position, scn.text, scn.ch, (ListCompletionMethod)scn.listCompletionMethod));
+                        OnAutoCCompleted(new AutoCSelectionEventArgs(this, scn.position.ToInt32(), scn.text, scn.ch, (ListCompletionMethod)scn.listCompletionMethod));
                         break;
 
                     case NativeMethods.SCN_AUTOCCANCELLED:
@@ -2765,11 +2765,11 @@ namespace ScintillaNET
                         break;
 
                     case NativeMethods.SCN_DWELLSTART:
-                        OnDwellStart(new DwellEventArgs(this, scn.position, scn.x, scn.y));
+                        OnDwellStart(new DwellEventArgs(this, scn.position.ToInt32(), scn.x, scn.y));
                         break;
 
                     case NativeMethods.SCN_DWELLEND:
-                        OnDwellEnd(new DwellEventArgs(this, scn.position, scn.x, scn.y));
+                        OnDwellEnd(new DwellEventArgs(this, scn.position.ToInt32(), scn.x, scn.y));
                         break;
 
                     case NativeMethods.SCN_DOUBLECLICK:
@@ -2777,7 +2777,7 @@ namespace ScintillaNET
                         break;
 
                     case NativeMethods.SCN_NEEDSHOWN:
-                        OnNeedShown(new NeedShownEventArgs(this, scn.position, scn.length));
+                        OnNeedShown(new NeedShownEventArgs(this, scn.position.ToInt32(), scn.length.ToInt32()));
                         break;
 
                     case NativeMethods.SCN_HOTSPOTCLICK:


### PR DESCRIPTION
These were changed from `int` in Scintilla a few years ago.

Closes #405
Closes #434
Closes #454