### PR TITLE
Add clarion language support

### DIFF
--- a/src/ScintillaNET/Lexer.cs
+++ b/src/ScintillaNET/Lexer.cs
@@ -37,6 +37,15 @@ namespace ScintillaNET
         Batch = NativeMethods.SCLEX_BATCH,
 
         /// <summary>
+        /// The Clarion language 
+        /// </summary>
+        Clw = NativeMethods.SCLEX_CLW,
+
+        /// <summary>
+        /// The Clarion language No Case 
+        /// </summary>
+        ClwNoCase = NativeMethods.SCLEX_CLWNOCASE,
+        /// <summary>
         /// The C language family (C++, C, C#, Java, JavaScript, etc...) lexer.
         /// </summary>
         Cpp = NativeMethods.SCLEX_CPP,

--- a/src/ScintillaNET/NativeMethods.cs
+++ b/src/ScintillaNET/NativeMethods.cs
@@ -1322,6 +1322,26 @@ namespace ScintillaNET
         public const int SCE_C_TASKMARKER = 26;
         public const int SCE_C_ESCAPESEQUENCE = 27;
 
+
+        //CLW
+        public const int SCE_CLW_DEFAULT = 0;
+        public const int SCE_CLW_LABEL = 1;
+        public const int SCE_CLW_COMMENT = 2;
+        public const int SCE_CLW_STRING = 3;
+        public const int SCE_CLW_USER_IDENTIFIER = 4;
+        public const int SCE_CLW_INTEGER_CONSTANT = 5;
+        public const int SCE_CLW_REAL_CONSTANT = 6;
+        public const int SCE_CLW_PICTURE_STRING = 7;
+        public const int SCE_CLW_KEYWORD = 8;
+        public const int SCE_CLW_COMPILER_DIRECTIVE = 9;
+        public const int SCE_CLW_RUNTIME_EXPRESSIONS = 10;
+        public const int SCE_CLW_BUILTIN_PROCEDURES_FUNCTION = 11;
+        public const int SCE_CLW_STRUCTURE_DATA_TYPE = 12;
+        public const int SCE_CLW_ATTRIBUTE = 13;
+        public const int SCE_CLW_STANDARD_EQUATE = 14;
+        public const int SCE_CLW_ERROR = 15;
+        public const int SCE_CLW_DEPRECATED = 16;
+
         // CSS
         public const int SCE_CSS_DEFAULT = 0;
         public const int SCE_CSS_TAG = 1;

--- a/src/ScintillaNET/Style.cs
+++ b/src/ScintillaNET/Style.cs
@@ -702,6 +702,101 @@ namespace ScintillaNET
 
         #endregion Batch
 
+        #region Clw
+
+        /// <summary>
+        /// Style constants for use with the <see cref="Lexer.Clw" /> lexer.
+        /// </summary>
+        public static class CLW
+        {
+            /// <summary>
+            /// Attributes style index
+            /// </summary>
+            public const int Attributes = NativeMethods.SCE_CLW_ATTRIBUTE;
+            
+            /// <summary>
+            /// Built in procedures function style index.
+            /// </summary>
+            public const int BuiltInProceduresFunction = NativeMethods.SCE_CLW_BUILTIN_PROCEDURES_FUNCTION;
+            
+            /// <summary>
+            /// Comment style index.
+            /// </summary>
+            public const int Comment = NativeMethods.SCE_CLW_COMMENT;
+
+            /// <summary>
+            /// Compiler directive style index
+            /// </summary>
+            public const int CompilerDirective = NativeMethods.SCE_CLW_COMPILER_DIRECTIVE;
+
+            /// <summary>
+            /// Default (whitespace) style index.
+            /// </summary>
+            public const int Default = NativeMethods.SCE_CLW_DEFAULT;
+            
+            /// <summary>
+            /// Depreciated style index
+            /// </summary>
+            public const int Depreciated = NativeMethods.SCE_CLW_DEPRECATED;
+            
+            /// <summary>
+            /// Error style index
+            /// </summary>
+            public const int Error = NativeMethods.SCE_CLW_ERROR;
+            
+            /// <summary>
+            /// Integer Constant style index.
+            /// </summary>
+            public const int IntegerConstant = NativeMethods.SCE_CLW_INTEGER_CONSTANT;
+            
+            /// <summary>
+            /// Keyword style index
+            /// </summary>
+            public const int Keyword = NativeMethods.SCE_CLW_KEYWORD;
+            
+            /// <summary>
+            /// Label string style index.
+            /// </summary>
+            public const int Label = NativeMethods.SCE_CLW_LABEL;
+
+            /// <summary>
+            /// Real Constant style index.
+            /// </summary>
+            public const int PictureString = NativeMethods.SCE_CLW_PICTURE_STRING;
+            
+            /// <summary>
+            /// Real Constant style index.
+            /// </summary>
+            public const int RealConstant = NativeMethods.SCE_CLW_REAL_CONSTANT;
+
+            /// <summary>
+            /// Runtime expressions style index
+            /// </summary>
+            public const int RuntimeExpressions = NativeMethods.SCE_CLW_RUNTIME_EXPRESSIONS;
+            
+            /// <summary>
+            /// Standard equates style index
+            /// </summary>
+            public const int StandardEquates = NativeMethods.SCE_CLW_STANDARD_EQUATE;
+            
+            /// <summary>
+            /// Single-quoted string style index.
+            /// </summary>
+            public const int String = NativeMethods.SCE_CLW_STRING;
+            
+            /// <summary>
+            /// Structure data type style index.
+            /// </summary>
+            public const int StructureDataTypes = NativeMethods.SCE_CLW_STRUCTURE_DATA_TYPE;
+            
+            /// <summary>
+            /// User Identifier style index.
+            /// </summary>
+            public const int UserIdentifier = NativeMethods.SCE_CLW_USER_IDENTIFIER;
+        }
+
+        #endregion Clw
+
         #region Cpp
 
         /// <summary>


### PR DESCRIPTION
I have added support for the clarion language.

The lexer for the language was added to Scintilla many years ago by Ron Schofield. This weekend I had a need to create an editor in .Net that supports it, and I Forked your great work.

Thanks for your time.

Mark